### PR TITLE
20220106 fixes

### DIFF
--- a/docs/blueprint-library/airtable/airtable-overview.md
+++ b/docs/blueprint-library/airtable/airtable-overview.md
@@ -16,14 +16,14 @@ keywords:
 
 Shipyard's low-code Airtable blueprints allow users to connect their Airtable bases to the rest of their modern data stack.
 
+## How to Use
+
+For information on how to set up these Blueprints successfully, please read through the [Airtable Authorization guide](airtable-authorization.md).
+
 ## Available Blueprints
 
 Shipyard currently has the following Blueprints readily available:
 - [Download Table or View to CSV](airtable-download-table-or-view-to-csv.md)
-
-## How to Use
-
-For information on how to set up these Blueprints successfully, please read through the [Airtable Authorization guide](airtable-authorization).
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/airtable-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/amazon-athena/amazon-athena-overview.md
+++ b/docs/blueprint-library/amazon-athena/amazon-athena-overview.md
@@ -15,14 +15,14 @@ keywords:
 
 Shipyard's low-code Amazon Athena blueprints allow users to connect their data in Amazon Athena to the rest of their data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Amazon Athena Authorization guide](amazon-athena-authorization.md).
+
 ## Available Blueprints
 
 Shipyard currently has the following Blueprints readily available:
-- [Execute Query](amazon-athena-execute-query)
-- [Store Query Results as CSV](amazon-athena-store-query-results-as-csv)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Amazon Athena Authorization guide](amazon-athena-authorization).
+- [Execute Query](amazon-athena-execute-query.md)
+- [Store Query Results as CSV](amazon-athena-store-query-results-as-csv.md)
 
 
 ## Open Source Code

--- a/docs/blueprint-library/amazon-redshift/amazon-redshift-overview.md
+++ b/docs/blueprint-library/amazon-redshift/amazon-redshift-overview.md
@@ -15,14 +15,14 @@ keywords:
 
 Shipyard's low-code Amazon Redshift blueprints allow users to connect their data in Amazon Redshift to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Amazon Redshift Authorization guide](amazon-redshift-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Execute Query](amazon-redshift-execute-query)
-- [Store Query Results as CSV](amazon-redshift-store-query-results-as-csv)
-- [Execute Query](amazon-redshift-upload-csv-to-table)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Amazon Redshift Authorization guide](amazon-redshift-authorization).
+- [Execute Query](amazon-redshift-execute-query.md)
+- [Store Query Results as CSV](amazon-redshift-store-query-results-as-csv.md)
+- [Execute Query](amazon-redshift-upload-csv-to-table.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/amazonredshift-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/amazon-s3/amazon-s3-overview.md
+++ b/docs/blueprint-library/amazon-s3/amazon-s3-overview.md
@@ -19,7 +19,7 @@ Shipyard's low-code Amazon S3 blueprints allow users to connect their data in Am
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
 - [Download Files](amazon-s3-download-files)
-- [Upload Files](amazon-s3-download-files)
+- [Upload Files](amazon-s3-upload-files)
 
 ## How to Use
 For information on how to set up these Blueprints successfully, please read through the [Amazon S3 Authorization guide](amazon-s3-authorization).

--- a/docs/blueprint-library/amazon-s3/amazon-s3-overview.md
+++ b/docs/blueprint-library/amazon-s3/amazon-s3-overview.md
@@ -15,14 +15,13 @@ keywords:
 
 Shipyard's low-code Amazon S3 blueprints allow users to connect their data in Amazon S3 to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Amazon S3 Authorization guide](amazon-s3-authorization.md).
 
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Files](amazon-s3-download-files)
-- [Upload Files](amazon-s3-upload-files)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Amazon S3 Authorization guide](amazon-s3-authorization).
+- [Download Files](amazon-s3-download-files.md)
+- [Upload Files](amazon-s3-upload-files.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/amazons3-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/azure-blob-storage/azure-blob-storage-overview.md
+++ b/docs/blueprint-library/azure-blob-storage/azure-blob-storage-overview.md
@@ -15,13 +15,13 @@ keywords:
 
 Shipyard's low-code Azure Blob Storage blueprints allow users to connect their data in Azure Blob Storage to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Azure Blob Storage Authorization guide](azure-blob-storage-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Files](azure-blob-storage-download-files)
-- [Upload Files](azure-blob-storage-upload-files)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Azure Blob Storage Authorization guide](azure-blob-storage-authorization).
+- [Download Files](azure-blob-storage-download-files.md)
+- [Upload Files](azure-blob-storage-upload-files.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/azurestorage-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/box/box-overview.md
+++ b/docs/blueprint-library/box/box-overview.md
@@ -15,13 +15,13 @@ keywords:
 
 Shipyard's low-code Box blueprints allow users to connect their data in Box to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Box Authorization guide](box-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Files](box-download-files)
-- [Upload Files](box-upload-files)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Box Authorization guide](box-authorization).
+- [Download Files](box-download-files.md)
+- [Upload Files](box-upload-files.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/box-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/data-manipulation/data-manipulation-overview.md
+++ b/docs/blueprint-library/data-manipulation/data-manipulation-overview.md
@@ -17,7 +17,7 @@ Shipyard's low-code Data Manipulation blueprints allow users to quickly transfor
 
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Compare Datasets](data-manipulation-compare-datasets)
+- [Compare Datasets](data-manipulation-compare-datasets.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/datamanipulation-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/dbt-cloud/dbt-cloud-overview.md
+++ b/docs/blueprint-library/dbt-cloud/dbt-cloud-overview.md
@@ -26,15 +26,15 @@ Sub-folders can be any of the following:
 
 If you would like to run **dbt Core** directly from Shipyard, rather than executing dbt on a separate platform, follow our [dbt Core Blueprint tutorial](../../tutorials/dbt-blueprint.md).
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [dbt Cloud Authorization guide](dbt-cloud-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Execute Job](dbt-cloud-execute-job)
-- [Check Run Status](dbt-cloud-check-run-status)
-- [Download Logs and Artifacts](dbt-cloud-download-logs-and-artifacts)
-- [Execute Job & Download Results](dbt-cloud-execute-job-and-download-results)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [dbt Cloud Authorization guide](dbt-cloud-authorization).
+- [Execute Job](dbt-cloud-execute-job.md)
+- [Check Run Status](dbt-cloud-check-run-status.md)
+- [Download Logs and Artifacts](dbt-cloud-download-logs-and-artifacts.md)
+- [Execute Job & Download Results](dbt-cloud-execute-job-and-download-results.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/dbtcloud-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/dropbox/dropbox-overview.md
+++ b/docs/blueprint-library/dropbox/dropbox-overview.md
@@ -15,13 +15,13 @@ keywords:
 
 Shipyard's low-code Dropbox blueprints allow users to connect their data in Dropbox to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Dropbox Authorization guide](dropbox-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Files](dropbox-download-files)
-- [Upload Files](dropbox-upload-files)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Dropbox Authorization guide](dropbox-authorization).
+- [Download Files](dropbox-download-files.md)
+- [Upload Files](dropbox-upload-files.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/dropbox-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/email/email-overview.md
+++ b/docs/blueprint-library/email/email-overview.md
@@ -15,16 +15,17 @@ keywords:
 
 Shipyard's low-code email blueprints allow users to connect their data to their email.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Email Authorization guide](email-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Send Message](email-send-message)
-- [Send Message Conditionally](email-send-message-conditionally)
-- [Send Message with File](email-send-message-with-file)
+- [Send Message](email-send-message.md)
+- [Send Message Conditionally](email-send-message-conditionally.md)
+- [Send Message with File](email-send-message-with-file.md)
 
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Email Authorization guide](email-authorization).
-
-Running into issues? Read our [Email Troubleshooting guide](email-troubleshooting).
+## Troubleshooting and Debugging
+Running into issues? Read our [Email Troubleshooting guide](email-troubleshooting.md).
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/email-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/file-manipulation/file-manipulation-overview.md
+++ b/docs/blueprint-library/file-manipulation/file-manipulation-overview.md
@@ -17,9 +17,9 @@ Shipyard's low-code file manipulation blueprints allow users to turn their data 
 
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Compress Files](file-manipulation-compress-files)
-- [Decompress Files](file-manipulation-decompress-files)
-- [Convert CSV](file-manipulation-convert-csv)
+- [Compress Files](file-manipulation-compress-files.md)
+- [Decompress Files](file-manipulation-decompress-files.md)
+- [Convert CSV](file-manipulation-convert-csv.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/filemanipulation-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/fivetran/fivetran-overview.md
+++ b/docs/blueprint-library/fivetran/fivetran-overview.md
@@ -30,15 +30,15 @@ If you would like to run an action against Fivetran that is not built out as a B
 These Blueprints will only work for Fivetran customers that have API access (Starter and Enterprise Plans).
 :::
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Fivetran Authorization guide](fivetran-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Execute Sync](fivetran-execute-sync)
-- [Check Sync Status](fivetran-check-sync-status)
-- [Execute Sync and Check Status](fivetran-execute-sync-and-check-status)
-- [Update Connector](fivetran-update-connector)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Fivetran Authorization guide](fivetran-authorization).
+- [Execute Sync](fivetran-execute-sync.md)
+- [Check Sync Status](fivetran-check-sync-status.md)
+- [Execute Sync and Check Status](fivetran-execute-sync-and-check-status.md)
+- [Update Connector](fivetran-update-connector.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/fivetran-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/ftp/ftp-overview.md
+++ b/docs/blueprint-library/ftp/ftp-overview.md
@@ -15,13 +15,13 @@ keywords:
 
 Shipyard's low-code FTP blueprints allow users to connect their data in FTP to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [FTP Authorization guide](ftp-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Files](ftp-download-files)
-- [Upload Files](ftp-upload-files)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [FTP Authorization guide](FTP-authorization).
+- [Download Files](ftp-download-files.md)
+- [Upload Files](ftp-upload-files.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/ftp-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/google-bigquery/google-bigquery-overview.md
+++ b/docs/blueprint-library/google-bigquery/google-bigquery-overview.md
@@ -15,15 +15,15 @@ keywords:
 
 Shipyard's low-code Google BigQuery blueprints allow users to connect their data in Google BigQuery to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Google BigQuery Authorization guide](google-bigquery-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Execute Query](google-bigquery-execute-query)
-- [Store Query Results in Google Cloud Storage](google-bigquery-store-query-results-in-google-cloud-storage)
-- [Store Query Results as CSV](google-bigquery-store-query-results-as-csv)
-- [Upload CSV to Table](google-bigquery-upload-csv-to-table)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Google BigQuery Authorization guide](google-bigquery-authorization).
+- [Execute Query](google-bigquery-execute-query.md)
+- [Store Query Results in Google Cloud Storage](google-bigquery-store-query-results-in-google-cloud-storage.md)
+- [Store Query Results as CSV](google-bigquery-store-query-results-as-csv.md)
+- [Upload CSV to Table](google-bigquery-upload-csv-to-table.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/googlebigquery-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/google-cloud-storage/google-cloud-storage-overview.md
+++ b/docs/blueprint-library/google-cloud-storage/google-cloud-storage-overview.md
@@ -15,13 +15,13 @@ keywords:
 
 Shipyard's low-code Google Cloud Storage blueprints allow users to connect their data in Google Cloud Storage to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Google Cloud Storage Authorization guide](google-cloud-storage-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Files](google-cloud-storage-download-files)
-- [Upload Files](google-cloud-storage-upload-files)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Google Cloud Storage Authorization guide](google-cloud-storage-authorization).
+- [Download Files](google-cloud-storage-download-files.md)
+- [Upload Files](google-cloud-storage-upload-files.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/googlecloudstorage-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/google-drive/google-drive-overview.md
+++ b/docs/blueprint-library/google-drive/google-drive-overview.md
@@ -16,13 +16,14 @@ keywords:
 
 Shipyard's low-code Google Drive blueprints allow users to connect their data in Google Drive to the rest of their modern data stack.
 
+## How to Use  
+For information on how to set up these Blueprints successfully, please read through the [Google Drive Authorization guide](google-drive-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Files](google-drive-download-files)
-- [Upload Files](google-drive-upload-files)
-  
-## How to Use  
-For information on how to set up these Blueprints successfully, please read through the [Google Drive Authorization guide](google-drive-authorization).
+- [Download Files](google-drive-download-files.md)
+- [Upload Files](google-drive-upload-files.md)
+
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/googledrive-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/google-drive/google-drive-overview.md
+++ b/docs/blueprint-library/google-drive/google-drive-overview.md
@@ -19,7 +19,7 @@ Shipyard's low-code Google Drive blueprints allow users to connect their data in
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
 - [Download Files](google-drive-download-files)
-- [Upload Files](google-drive-download-files)
+- [Upload Files](google-drive-upload-files)
   
 ## How to Use  
 For information on how to set up these Blueprints successfully, please read through the [Google Drive Authorization guide](google-drive-authorization).

--- a/docs/blueprint-library/google-sheets/google-sheets-overview.md
+++ b/docs/blueprint-library/google-sheets/google-sheets-overview.md
@@ -15,14 +15,14 @@ keywords:
 
 Shipyard's low-code Google Sheets blueprints allow users to connect their data in Google Sheets to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Google Sheets Authorization guide](google-sheets-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Sheet to CSV](google-sheets-download-sheet-to-csv)
-- [Upload CSV to Sheet](google-sheets-upload-csv-to-sheet)
-- [Clear Data from Sheet](google-sheets-clear-data-from-sheet)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Google Sheets Authorization guide](google-sheets-authorization).
+- [Download Sheet to CSV](google-sheets-download-sheet-to-csv.md)
+- [Upload CSV to Sheet](google-sheets-upload-csv-to-sheet.md)
+- [Clear Data from Sheet](google-sheets-clear-data-from-sheet.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/googlesheets-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/http/http-overview.md
+++ b/docs/blueprint-library/http/http-overview.md
@@ -17,8 +17,8 @@ keywords:
 Shipyard's low-code HTTP blueprints allow users to connect data from any HTTP API to the rest of their modern data stack.
 
 Shipyard currently has the following Blueprints readily available:
-- [Requests](http-requests)
-- [Download File from URL](http-download-file-from-url)
+- [Requests](http-requests.md)
+- [Download File from URL](http-download-file-from-url.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/http-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/microsoft-sql-server/microsoft-sql-server-overview.md
+++ b/docs/blueprint-library/microsoft-sql-server/microsoft-sql-server-overview.md
@@ -15,15 +15,14 @@ keywords:
 
 Shipyard's low-code Microsoft SQL Server blueprints allow users to connect their data in Microsoft SQL Server to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Microsoft SQL Server Authorization guide](microsoft-sql-server-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Execute Query](microsoft-sql-server-execute-query)
-- [Store Query Results as CSV](microsoft-sql-server-store-query-results-as-csv)
-- [Upload CSV to Table](microsoft-sql-server-upload-csv-to-table)
-
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Microsoft SQL Server Authorization guide](microsoft-sql-server-authorization).
+- [Execute Query](microsoft-sql-server-execute-query.md)
+- [Store Query Results as CSV](microsoft-sql-server-store-query-results-as-csv.md)
+- [Upload CSV to Table](microsoft-sql-server-upload-csv-to-table.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/microsoftsqlserver-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/mysql/mysql-overview.md
+++ b/docs/blueprint-library/mysql/mysql-overview.md
@@ -15,14 +15,14 @@ keywords:
 
 Shipyard's low-code MySQL blueprints allow users to connect their data in MySQL to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [MySQL Authorization guide](mysql-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Execute Query](mysql-execute-query)
-- [Store Query Results as CSV](mysql-store-query-results-as-csv)
-- [Upload CSV to Table](mysql-upload-csv-to-table)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [MySQL Authorization guide](mysql-authorization).
+- [Execute Query](mysql-execute-query.md)
+- [Store Query Results as CSV](mysql-store-query-results-as-csv.md)
+- [Upload CSV to Table](mysql-upload-csv-to-table.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/mysql-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/postgresql/postgresql-overview.md
+++ b/docs/blueprint-library/postgresql/postgresql-overview.md
@@ -15,14 +15,14 @@ keywords:
 
 Shipyard's low-code PostgreSQL blueprints allow users to connect their data in PostgreSQL to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [PostgreSQL Authorization guide](postgresql-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Execute Query](postgresql-execute-query)
-- [Store Query Results as CSV](postgresql-store-query-results-as-csv)
-- [Upload CSV to Table](postgresql-upload-csv-to-table)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [PostgreSQL Authorization guide](postgresql-authorization).
+- [Execute Query](postgresql-execute-query.md)
+- [Store Query Results as CSV](postgresql-store-query-results-as-csv.md)
+- [Upload CSV to Table](postgresql-upload-csv-to-table.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/postgresql-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/sftp/sftp-overview.md
+++ b/docs/blueprint-library/sftp/sftp-overview.md
@@ -18,7 +18,7 @@ Shipyard's low-code SFTP blueprints allow users to connect their data in SFTP to
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
 - [Download Files](sftp-download-files)
-- [Upload Files](sftp-download-files)
+- [Upload Files](sftp-upload-files)
 
 ## How to Use
 For information on how to set up these Blueprints successfully, please read through the [SFTP Authorization guide](sftp-authorization).

--- a/docs/blueprint-library/sftp/sftp-overview.md
+++ b/docs/blueprint-library/sftp/sftp-overview.md
@@ -15,13 +15,13 @@ keywords:
 
 Shipyard's low-code SFTP blueprints allow users to connect their data in SFTP to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [SFTP Authorization guide](sftp-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Download Files](sftp-download-files)
-- [Upload Files](sftp-upload-files)
-
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [SFTP Authorization guide](sftp-authorization).
+- [Download Files](sftp-download-files.md)
+- [Upload Files](sftp-upload-files.md)
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/sftp-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/slack/slack-overview.md
+++ b/docs/blueprint-library/slack/slack-overview.md
@@ -15,16 +15,17 @@ keywords:
 
 Shipyard's low-code Slack blueprints allow users to connect their data to Slack. You can send messages to public channels, private channels, or DMs.  
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Slack Authorization guide](slack-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Send Message](slack-send-message)
-- [Send Message Conditionally](slack-send-message-conditionally)
-- [Send Message with File](slack-send-message-with-file)
+- [Send Message](slack-send-message.md)
+- [Send Message Conditionally](slack-send-message-conditionally.md)
+- [Send Message with File](slack-send-message-with-file.md)
 
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Slack Authorization guide](slack-authorization).
-
-Running into issues? Read our [Slack Troubleshooting guide](slack-troubleshooting).
+## Troubleshooting and Debugging
+Running into issues? Read our [Slack Troubleshooting guide](slack-troubleshooting.md).
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/slack-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/snowflake/snowflake-overview.md
+++ b/docs/blueprint-library/snowflake/snowflake-overview.md
@@ -15,16 +15,17 @@ keywords:
 
 Shipyard's low-code Snowflake blueprints allow users to connect their data in Snowflake to the rest of their modern data stack.
 
+## How to Use
+For information on how to set up these Blueprints successfully, please read through the [Snowflake Authorization guide](snowflake-authorization.md).
+
 ## Available Blueprints
 Shipyard currently has the following Blueprints readily available:
-- [Execute Query](snowflake-execute-query)
-- [Store Query Results as CSV](snowflake-store-query-results-as-csv)
-- [Upload CSV to Table](snowflake-upload-csv-to-table)
+- [Execute Query](snowflake-execute-query.md)
+- [Store Query Results as CSV](snowflake-store-query-results-as-csv.md)
+- [Upload CSV to Table](snowflake-upload-csv-to-table.md)
 
-## How to Use
-For information on how to set up these Blueprints successfully, please read through the [Snowflake Authorization guide](snowflake-authorization).
-
-Running into issues? Read our [Snowflake Troubleshooting guide](snowflake-troubleshooting).
+## Troubleshooting and Debugging
+Running into issues? Read our [Snowflake Troubleshooting guide](snowflake-troubleshooting.md).
 
 ## Open Source Code
 The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/snowflake-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/reference/blueprint-library/blueprint-library-overview.md
+++ b/docs/reference/blueprint-library/blueprint-library-overview.md
@@ -27,40 +27,96 @@ Library Blueprints are immediately available to every user in an organization. T
 
 In an effort to be transparent about how our Blueprints work, we open-source the code and make it available on our [GitHub](https://github.com/shipyardapp). The repositories are broken up by vendor and all end in `-blueprints`. If some functionality isn't working appropriately, you can open an issue in GitHub or submit a pull request with the proposed changes.
 
-### Categories and Actions
+## Types of Blueprints
 
-Blueprints are broken down into a few categories with core functionality that should be achieved.
+Blueprints are broken down into a few categories with core functionality that should be achieved. The following is a list of the integrations currently built out and the possible actions related to each category.
 
-**Databases**
+### Databases
+ 
+#### Integrations
+- [Amazon Athena](../../blueprint-library/amazon-athena/amazon-athena-overview.md)
+- [Amazon Redshift](../../blueprint-library/amazon-redshift/amazon-redshift-overview.md)
+- [Google Bigquery](../../blueprint-library/google-bigquery/google-bigquery-overview.md)
+- [Microsoft SQL Server](../../blueprint-library/microsoft-sql-server/microsoft-sql-server-overview.md)
+- [MySQL](../../blueprint-library/mysql/mysql-overview.md)
+- [PostgreSQL](../../blueprint-library/postgresql/postgresql-overview.md)
+- [Snowflake](../../blueprint-library/snowflake/snowflake-overview.md)
 
+#### Actions
 - Execute SQL Queries
 - Store Query Results as a CSV
 - Upload a CSV to a Table
 
-**Cloud Storage**
+### Cloud Storage
 
+#### Integrations
+- [Amazon S3](../../blueprint-library/amazon-s3/amazon-s3-overview.md)
+- [Azure Blob Storage](../../blueprint-library/azure-blob-storage/azure-blob-storage-overview.md)
+- [Box](../../blueprint-library/box/box-overview.md)
+- [Dropbox](../../blueprint-library/dropbox/dropbox-overview.md)
+- [FTP](../../blueprint-library/ftp/ftp-overview.md)
+- [Google Cloud Storage](../../blueprint-library/google-cloud-storage/google-cloud-storage-overview.md)
+- [Google Drive](../../blueprint-library/google-drive/google-drive-overview.md)
+- [SFTP](../../blueprint-library/sftp/sftp-overview.md)
+
+#### Actions
 - Upload Files
 - Download Files
 
-**Spreadsheets**
+### Spreadsheets
 
+#### Integrations
+- [Airtable](../../blueprint-library/airtable/airtable-overview.md)
+- [Google Sheets](../../blueprint-library/google-sheets/google-sheets-overview.md)
+
+#### Actions
 - Download Sheet to a CSV
 - Upload CSV to a Sheet
+- Clear Sheet Contents
 
-**Messaging**
+### Messaging
 
+#### Integrations
+- [Email](../../blueprint-library/email/email-overview.md)
+- [Slack](../../blueprint-library/email/email-overview.md)
+
+#### Actions
 - Send Message
+- Send Message Conditionally
 - Send Message w/ Attachment
 
-**File Manipulation**
+### File or Data Manipulation
 
+#### Integrations
+- [Data Manipulation](../../blueprint-library/data-manipulation/data-manipulation-overview.md)
+- [File Manipulation](../../blueprint-library/file-manipulation/file-manipulation-overview.md)
+
+#### Actions
 - Compress Files
 - Decompress Files
 - Convert Files
+- Compare File Contents
 
-**Data Manipulation**
+### Data Ingestion, Transformation, and Syncing
 
-- Run SQL against a CSV
+#### Integrations
+- [Fivetran](../../blueprint-library/fivetran/fivetran-overview.md)
+- [dbt Cloud](../../blueprint-library/dbt-cloud/dbt-cloud-overview.md)
+
+#### Actions
+- Execute Job
+- Check Status of Job
+- Download Results from Job
+- Execute Job, Check Status, and Download Results (All-in-one)
+
+### 3rd-Party APIs
+
+#### Integrations
+- [HTTP](../../blueprint-library/http/http-overview.md)
+
+#### Actions
+- HTTP Request
+- Download File from URL
 
 ## Screenshots
 


### PR DESCRIPTION
- Fixes 404 issues with links that didn't include .md
- Reorders "How to use" section per Eric's feedback
- Separates troubleshooting section, where available
- Includes BPL links on the reference page.