### PR TITLE
Update http-overview.md

### DIFF
--- a/docs/blueprint-library/http/http-overview.md
+++ b/docs/blueprint-library/http/http-overview.md
@@ -21,7 +21,7 @@ Shipyard currently has the following Blueprints readily available:
 - [Download File from URL](./http-download-file-from-url.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/http-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/httprequest-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
 
 ## Helpful HTTP Links
 - [Python Requests Library](https://docs.python-requests.org/en/latest/)  


### PR DESCRIPTION
- Fixes broken link GitHub
- Note: the Python Requests Library currently gives a `Your connection is not private` warning. Not sure if this needs an update.