### PR TITLE
GitHub monorepo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ yarn-error.log*
 
 # Local Configuration
 /etc
+
+# python environment
+docenv/

--- a/docs/blueprint-library/airtable/airtable-overview.md
+++ b/docs/blueprint-library/airtable/airtable-overview.md
@@ -25,4 +25,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download Table or View to Shipyard](airtable-download-table-or-view-to-csv.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/airtable-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/airtable), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/amazon-athena/amazon-athena-overview.md
+++ b/docs/blueprint-library/amazon-athena/amazon-athena-overview.md
@@ -26,4 +26,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download Query Results to Shipyard](amazon-athena-store-query-results-as-csv.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/amazonathena-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/athena), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/amazon-redshift/amazon-redshift-overview.md
+++ b/docs/blueprint-library/amazon-redshift/amazon-redshift-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download Query Results to Shipyard](amazon-redshift-store-query-results-as-csv.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/amazonredshift-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/redshift), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/amazon-s3/amazon-s3-overview.md
+++ b/docs/blueprint-library/amazon-s3/amazon-s3-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Delete Files](amazon-s3-remove-files.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/amazons3-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/s3), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/asana/asana-overview.md
+++ b/docs/blueprint-library/asana/asana-overview.md
@@ -26,4 +26,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Edit Task](asana-edit-task.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/asana), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/azure-blob-storage/azure-blob-storage-overview.md
+++ b/docs/blueprint-library/azure-blob-storage/azure-blob-storage-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Delete Files](azure-blob-storage-remove-files.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/azurestorage-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/azureblob), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/box/box-overview.md
+++ b/docs/blueprint-library/box/box-overview.md
@@ -26,4 +26,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download Files to Shipyard](box-download-files.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/box-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/box), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/census/census-overview.md
+++ b/docs/blueprint-library/census/census-overview.md
@@ -26,4 +26,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Check Sync Status (Deprecated)](census-check-sync-status.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/census-blueprints/tree/main/census_blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/census), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/data-manipulation/data-manipulation-overview.md
+++ b/docs/blueprint-library/data-manipulation/data-manipulation-overview.md
@@ -20,7 +20,7 @@ Shipyard currently has the following Blueprints readily available:
 - [Compare Datasets](data-manipulation-compare-datasets.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/datamanipulation-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/filemanipulation), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
 
 ## Helpful Data Manipulation Links
 - [Pandas](https://pandas.pydata.org/docs/index.html)  

--- a/docs/blueprint-library/databricks/databricks-overview.md
+++ b/docs/blueprint-library/databricks/databricks-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Upload Files to DBFS from Shipyard](databricks-upload-files-to-dbfs.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/databricks-blueprints/blob/main/databricks_blueprints/upload_file_to_dbfs.py), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/databricks), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/dbt-cloud/dbt-cloud-overview.md
+++ b/docs/blueprint-library/dbt-cloud/dbt-cloud-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Check Run Status (Deprecated)](dbt-cloud-check-run-status.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/dbtcloud-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/dbt), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/domo/domo-overview.md
+++ b/docs/blueprint-library/domo/domo-overview.md
@@ -29,4 +29,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Trigger Dataset Refresh](domo-refresh-dataset.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/domo-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/domo), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/dropbox/dropbox-overview.md
+++ b/docs/blueprint-library/dropbox/dropbox-overview.md
@@ -26,4 +26,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Upload Files from Shipyard](dropbox-upload-files.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/dropbox-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/dropbox), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/email/email-overview.md
+++ b/docs/blueprint-library/email/email-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Send Message Conditionally](email-send-message-conditionally.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/email-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/email), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/file-manipulation/file-manipulation-overview.md
+++ b/docs/blueprint-library/file-manipulation/file-manipulation-overview.md
@@ -21,4 +21,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Decompress Files](file-manipulation-decompress-files.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/filemanipulation-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/filemanipulation), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/ftp/ftp-overview.md
+++ b/docs/blueprint-library/ftp/ftp-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Delete Files](ftp-remove-files.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/ftp-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/ftp), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/google-bigquery/google-bigquery-overview.md
+++ b/docs/blueprint-library/google-bigquery/google-bigquery-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download Query Results to Google Cloud Storage](google-bigquery-store-query-results-in-google-cloud-storage.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/googlebigquery-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/bigquery), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/google-cloud-storage/google-cloud-storage-overview.md
+++ b/docs/blueprint-library/google-cloud-storage/google-cloud-storage-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download Files to Shipyard](google-cloud-storage-download-files.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/googlecloudstorage-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/googlecloud), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/google-sheets/google-sheets-overview.md
+++ b/docs/blueprint-library/google-sheets/google-sheets-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Upload File to Sheet from Shipyard](google-sheets-upload-csv-to-sheet.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/googlesheets-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/googlesheets), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/hex/hex-overview.md
+++ b/docs/blueprint-library/hex/hex-overview.md
@@ -26,4 +26,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Check Run Status (Deprecated)](hex-check-run-status.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/hex-blueprints/blob/main/hex_blueprints/), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/hex), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/hightouch/hightouch-overview.md
+++ b/docs/blueprint-library/hightouch/hightouch-overview.md
@@ -26,4 +26,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Check Sync Status (Deprecated)](hightouch-check-sync-status.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/hightouch-blueprints/blob/main/hightouch_blueprints/execute_sync.py), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/hightouch), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/http/http-overview.md
+++ b/docs/blueprint-library/http/http-overview.md
@@ -21,4 +21,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download File from URL to Shipyard](http-download-file-from-url.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/httprequest-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/http), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/looker/looker-overview.md
+++ b/docs/blueprint-library/looker/looker-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download Dashboard as File to Shipyard](looker-download-dashboard-as-file.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/looker-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/looker), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/microsoft-sql-server/microsoft-sql-server-overview.md
+++ b/docs/blueprint-library/microsoft-sql-server/microsoft-sql-server-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Download Query Results to Shipyard](microsoft-sql-server-store-query-results-as-csv.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/microsoftsqlserver-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/sqlserver), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/mode/mode-overview.md
+++ b/docs/blueprint-library/mode/mode-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Trigger Report Refresh](mode-trigger-report-refresh.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/mode-blueprints/blob/main/mode_blueprints/run_report.py), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/mode), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/mysql/mysql-overview.md
+++ b/docs/blueprint-library/mysql/mysql-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Upload File to Table from Shipyard](mysql-upload-csv-to-table.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/mysql-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/mysql), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/postgresql/postgresql-overview.md
+++ b/docs/blueprint-library/postgresql/postgresql-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Upload File to Table from Shipyard](postgresql-upload-csv-to-table.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/postgresql-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/postgres_legacy), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/sftp/sftp-overview.md
+++ b/docs/blueprint-library/sftp/sftp-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Delete Files](sftp-delete-files.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/sftp-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/sftp), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/slack/slack-overview.md
+++ b/docs/blueprint-library/slack/slack-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Send Message Conditionally](slack-send-message-conditionally.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/slack-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/slack), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/snowflake/snowflake-overview.md
+++ b/docs/blueprint-library/snowflake/snowflake-overview.md
@@ -27,4 +27,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Upload File to Table from Shipyard](snowflake-upload-csv-to-table.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/snowflake-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/legacy_snowflake), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.

--- a/docs/blueprint-library/tableau/tableau-overview.md
+++ b/docs/blueprint-library/tableau/tableau-overview.md
@@ -28,4 +28,4 @@ Shipyard currently has the following Blueprints readily available:
 - [Trigger Datasource Refresh](tableau-trigger-datasource-refresh.md)
 
 ## Open Source Code
-The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/tableau-blueprints), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.
+The code that powers these Blueprints is [available on our Github](https://github.com/shipyardapp/shipyard-blueprints/tree/main/shipyard_blueprints/tableau), open sourced under the Apache License 2.0. We'd love to have you contribute to others using Shipyard Blueprints by creating issues or submitting PRs.


### PR DESCRIPTION
Updated the Github link to point to the monorepo instead of the legacy repositories